### PR TITLE
docs: Standardize capitalization and wording in documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,19 @@
 # Chain-of-Thought Hub Documentation
 
-- [build](#build)
+- [Build](#build)
+- [ChangeLog](#changelog)
 
-## build
+## Build
 
 ```bash
-# build the doc
+# build the docs
 pip install -U jupyter-book
 jupyter-book build docs/
 
-# take a look at the doc locally
+# take a look at the docs locally
 open docs/_build/html/index.html
 ```
+
+## ChangeLog
+
+- 2023-07-13 init


### PR DESCRIPTION
- Change heading "build" to "Build" in readme.md
- Update phrase "build the doc" to "build the docs" in readme.md
- Modify phrase "take a look at the doc locally" to "take a look at the docs locally" in readme.md
- Add "ChangeLog" section with initial entry for 2023-07-13 in readme.md